### PR TITLE
Fix/owner txt

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 ## Deployment
 
-![architecure_overview](docs/asset/overview.png)
+![architecture_overview](docs/asset/overview.png)
 
 The TFGateway works be reading the reservation detail from the TFExplorer. It then convert these reservation into configuration readable by the TCP Router server or CoreDNS and write them into a redis server.
 
@@ -94,7 +94,7 @@ apt -o Dpkg::Options::='--force-confold' --force-yes -fuy install linux-image-5.
 apt -y autoremove
 
 # That is, if ufw isn't installed by default
-apt -o Dpkg::Options::='--force-confold' --force-yes -fuy install ufw 
+apt -o Dpkg::Options::='--force-confold' --force-yes -fuy install ufw
 ufw allow 34022/tcp
 
 ech | ufw enable
@@ -104,10 +104,10 @@ systemctl enable ufw --now
 # you might want to install docker for some ungoldly reason too
 # curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add -
 # add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
-# 
+#
 # apt update
 # apt-get install docker-ce docker-ce-cli containerd.io -y
-# 
+#
 # systemctl enable docker --now
 
 # wget -qO - https://www.mongodb.org/static/pgp/server-4.2.asc | sudo apt-key add -
@@ -126,9 +126,9 @@ apt-get -y install wireguard
 
 For networking, I assume you know your way ;-)
 
-Anyway, so the gateway does several things when you want to expose a service. As your container with a service is not directly available for Internet access, you'll want to expose it in some way. 
+Anyway, so the gateway does several things when you want to expose a service. As your container with a service is not directly available for Internet access, you'll want to expose it in some way.
 
-First, you want your service to be reachable by a DNS name (fqdn) in a domain (that can be readily available or that you want to handle). 
+First, you want your service to be reachable by a DNS name (fqdn) in a domain (that can be readily available or that you want to handle).
 Secondly, the service you want to expose needs to be reachable.
 
 TFGateway manages as well a dns server (coredns) as a tcp proxy that accepts connections from clients an forwards it to your service.
@@ -142,7 +142,7 @@ your system might be running resolved and using port 53, needed to be freed for 
 - stop and disable redis unit `systemctl stop redis`
 - stop and disable systemd-resolved unit `systemctl stop systemd-resolved`
 
-Hence: 
+Hence:
 
 #### Some systemd units
 
@@ -151,16 +151,16 @@ Hence:
 ```
 [Unit]
 Description=The Redis server for TFGateway
-After=network.target 
+After=network.target
 
 [Service]
-Type=simple              
+Type=simple
 Environment=statedir=/run/redis
 PIDFile=/run/redis/redis.pid
-ExecStartPre=/bin/touch /var/log/redis.log 
+ExecStartPre=/bin/touch /var/log/redis.log
 ExecStartPre=/bin/mkdir -p ${statedir}
 ExecStart=/usr/local/bin/redis-server /etc/tfredis.conf
-ExecReload=/bin/kill -USR2 $MAINPID                          
+ExecReload=/bin/kill -USR2 $MAINPID
 MemoryAccounting=true
 MemoryHigh=800M
 MemoryMax=1G
@@ -232,7 +232,7 @@ MemoryMax=1G
 WantedBy=multi-user.target
 ```
 
-These services need some config, for our usecases it's all static. 
+These services need some config, for our usecases it's all static.
 
 `/etc/tfredis.conf`
 
@@ -276,7 +276,7 @@ There are 2 parts:
 
 ### DNS
 
-Let's start by playing a dns server for your client, that wants to reach www.myspecialname.gateway.tf.  
+Let's start by playing a dns server for your client, that wants to reach www.myspecialname.gateway.tf.
 
 Your client has a dns server (Recursive DNS server,Rdns) configured in it's IP configuration.
 A Recursive DNS server handles the queries for your client, ultimately returning an IP address for and FQDN.
@@ -292,9 +292,9 @@ Rdns -> `.tf` nameserver: Hey, `.tf` nameserver, I'm looking for a nameserver th
 
 `.tf` nameserver -> Rdns : you can go ask the server with that ip.
 
-Rdns -> `gateway.tf` nameserver: hey `gateway.tf` server, I want the IP address of `www.myspecialname.gateway.tf`. 
+Rdns -> `gateway.tf` nameserver: hey `gateway.tf` server, I want the IP address of `www.myspecialname.gateway.tf`.
 
-`gateway.tf` nameserver -> Rdns: Uh-oh, I'm not authoritative for that fqdn, actually `myspecialname` is a subdomain with it's own nameserver, go ask him, here is the ip address 
+`gateway.tf` nameserver -> Rdns: Uh-oh, I'm not authoritative for that fqdn, actually `myspecialname` is a subdomain with it's own nameserver, go ask him, here is the ip address
 
 Rdns -> `myspecialname.gateway.tf` nameserver : Hey `myspecialname.gateway.tf`, can you give me the IP address of `www` in your domain ?
 
@@ -312,7 +312,7 @@ The TCP Proxy is special in the sense that it contains 2 parts:
 
 The client-server part seems a bit convoluted, but please bear with me:
 
-The moment you want to expose a service, the grid adds a container in the same user network of the running service container, and starts a proxy, that is also a client towards the tfgateway server.  
+The moment you want to expose a service, the grid adds a container in the same user network of the running service container, and starts a proxy, that is also a client towards the tfgateway server.
 The tfgateway's tcp proxy connects the outside listener with the the proxy client in that addon container, and as such the the proxy in the addon container can forward the queries towards the service.
 
 
@@ -327,7 +327,7 @@ mkdir -p /etc/tcprouter
 
 
 
-cat << EOF > /etc/identity.seed 
+cat << EOF > /etc/identity.seed
 "1.1.0"{"mnemonic":"coral light army gather adapt blossom school alcohol coral light army gather adapt blossom school alcohol coral logic blue tragic danger response sister name","threebotid":2145}
 EOF
 
@@ -338,12 +338,12 @@ EOF
 
 cat << EOF > /etc/coredns/Corefile
 . {
-    log 
+    log
     errors
     redis  {
         address 127.0.0.1:6379
     }
-    forward . 174.138.6.79 8.8.8.8 1.1.1.1  
+    forward . 174.138.6.79 8.8.8.8 1.1.1.1
 }
 
 EOF
@@ -369,16 +369,16 @@ EOF
 cat << EOF > /etc/systemd/system/tfredis.service
 [Unit]
 Description=The Redis server for TFGateway
-After=network.target 
+After=network.target
 
 [Service]
-Type=simple              
+Type=simple
 Environment=statedir=/run/redis
 PIDFile=/run/redis/redis.pid
-ExecStartPre=/bin/touch /var/log/redis.log 
+ExecStartPre=/bin/touch /var/log/redis.log
 ExecStartPre=/bin/mkdir -p /run/redis
 ExecStart=redis-server /etc/tfredis.conf
-ExecReload=/bin/kill -USR2 $MAINPID                          
+ExecReload=/bin/kill -USR2 $MAINPID
 MemoryAccounting=true
 MemoryHigh=800M
 MemoryMax=1G

--- a/cmd/tfgateway/main.go
+++ b/cmd/tfgateway/main.go
@@ -46,7 +46,7 @@ var appCLI = cli.App{
 		},
 		&cli.StringFlag{
 			Name:  "explorer",
-			Value: "https://explorer.grid.tf/explorer",
+			Value: "https://explorer.grid.tf/api/v1",
 			Usage: "URL to the explorer API used to poll reservations",
 		},
 		&cli.StringFlag{
@@ -186,14 +186,16 @@ func run(c *cli.Context) error {
 	}
 
 	bo := backoff.NewExponentialBackOff()
-	bo.MaxElapsedTime = 0
-	if err := backoff.Retry(registerID(gw, e), bo); err != nil {
+	bo.MaxElapsedTime = 1 * time.Minute
+	bo.MaxInterval = 2 * time.Second
+	if err := backoff.RetryNotify(registerID(gw, e), bo, func(e error, d time.Duration) {
+		log.Err(e).Dur("sleep", d).Msg("failed to register to explorer")
+	}); err != nil {
 		return fmt.Errorf("failed to register gateway in the explorer: %w", err)
 	}
 
 	var wgMgr *wg.Mgr
 	if is4To6Enabled(c) {
-
 		// the Gateway4To6 workloads doesn't not survice gateway restart, so we clear all reservations from the
 		// cache so they are always re-provisionned
 		if err := localStore.ClearByType([]provision.ReservationType{tfgateway.Gateway4To6Reservation}); err != nil {

--- a/delegate.go
+++ b/delegate.go
@@ -21,7 +21,7 @@ func (p *Provisioner) domainDeleateProvision(ctx context.Context, r *provision.R
 	}
 	log.Info().Str("id", r.ID).Msgf("provision Delegate %+v", data)
 
-	return nil, p.dns.AddDomainDelagate(r.User, data.Domain)
+	return nil, p.dns.AddDomainDelagate(r.NodeID, r.User, data.Domain)
 }
 
 func (p *Provisioner) domainDeleateDecomission(ctx context.Context, r *provision.Reservation) error {

--- a/dns/coredns.go
+++ b/dns/coredns.go
@@ -284,7 +284,7 @@ func (c *Mgr) setZoneOwnerTXTRecord(domain, identity, owner string) error {
 	const name = "__owner__"
 	var zone Zone
 	// we are not using the ZoneOwner struct because of
-	// 1- backward compatability issue since it does not define json tags
+	// 1- backward compatibility issue since it does not define json tags
 	// 2- extendability of this struct with more data in the future
 	data := struct {
 		Identity string `json:"identity"`

--- a/dns/coredns.go
+++ b/dns/coredns.go
@@ -2,12 +2,12 @@ package dns
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
 	"net"
 	"strings"
 
 	"github.com/asaskevich/govalidator"
+	"github.com/pkg/errors"
 	"github.com/rs/zerolog/log"
 
 	"github.com/gomodule/redigo/redis"
@@ -258,7 +258,7 @@ func (c *Mgr) RemoveSubdomain(user string, domain string, IPs []net.IP) error {
 }
 
 // AddDomainDelagate configures coreDNS to manage domain
-func (c *Mgr) AddDomainDelagate(user, domain string) error {
+func (c *Mgr) AddDomainDelagate(identity, user, domain string) error {
 	if err := validateDomain(domain); err != nil {
 		return err
 	}
@@ -273,7 +273,35 @@ func (c *Mgr) AddDomainDelagate(user, domain string) error {
 	}
 
 	owner.Owner = user
-	return c.setZoneOwner(domain, owner)
+	if err := c.setZoneOwner(domain, owner); err != nil {
+		return errors.Wrap(err, "failed to set zone owner")
+	}
+
+	return c.setZoneOwnerTXTRecord(domain, identity, owner.Owner)
+}
+
+func (c *Mgr) setZoneOwnerTXTRecord(domain, identity, owner string) error {
+	const name = "__owner__"
+	var zone Zone
+	// we are not using the ZoneOwner struct because of
+	// 1- backward compatability issue since it does not define json tags
+	// 2- extendability of this struct with more data in the future
+	data := struct {
+		Identity string `json:"identity"`
+		Owner    string `json:"owner"`
+	}{
+		Identity: identity,
+		Owner:    owner,
+	}
+
+	bytes, err := json.Marshal(data)
+	if err != nil {
+		return errors.Wrap(err, "failed to create owner TXT record")
+	}
+
+	zone.Add(RecordTXT{Text: string(bytes), TTL: 600})
+
+	return c.setZoneRecords(domain, name, zone)
 }
 
 // RemoveDomainDelagate remove a delagated domain added with AddDomainDelagate

--- a/dns/coredns_test.go
+++ b/dns/coredns_test.go
@@ -193,6 +193,12 @@ func TestZoneRecords(t *testing.T) {
 					TTL: 3600,
 				},
 			},
+			RecordTypeTXT: []Record{
+				RecordTXT{
+					Text: "hello world",
+					TTL:  3600,
+				},
+			},
 		},
 	}
 
@@ -221,17 +227,18 @@ func TestDomainDelegate(t *testing.T) {
 
 	mgr := New(pool, "")
 
+	id := "id"
 	user := "user"
 	domain := "my.domain.com"
 
-	err = mgr.AddDomainDelagate(user, domain)
+	err = mgr.AddDomainDelagate(id, user, domain)
 	require.NoError(t, err)
 
 	err = mgr.RemoveDomainDelagate("user2", domain)
 	assert.Error(t, err, "a domain can only be remove by its owner")
 	assert.True(t, errors.Is(err, ErrAuth))
 
-	err = mgr.AddDomainDelagate("user2", domain)
+	err = mgr.AddDomainDelagate(id, "user2", domain)
 	assert.Error(t, err, "a domain cannot be overwritten by another user")
 	assert.True(t, errors.Is(err, ErrAuth))
 
@@ -248,6 +255,7 @@ func TestSubdomain(t *testing.T) {
 	require.NoError(t, err)
 	mgr := New(pool, "")
 
+	id := "id"
 	user := "user"
 	zone := "mydomain.com"
 	domain := fmt.Sprintf("test.%s", zone)
@@ -255,7 +263,7 @@ func TestSubdomain(t *testing.T) {
 		net.ParseIP("10.1.1.10"),
 	}
 
-	err = mgr.AddDomainDelagate(user, zone)
+	err = mgr.AddDomainDelagate(id, user, zone)
 	require.NoError(t, err)
 
 	err = mgr.AddSubdomain(user, domain, ips)
@@ -296,7 +304,7 @@ func TestSubdomainChangeOwner(t *testing.T) {
 	}
 
 	// the gateway manage a domain
-	err = mgr.AddDomainDelagate(gwid, domain)
+	err = mgr.AddDomainDelagate("id", gwid, domain)
 	require.NoError(t, err)
 
 	// a user create a subdomain
@@ -329,7 +337,7 @@ func TestManagedDomain(t *testing.T) {
 	}
 
 	// add the managed domain by the gateway
-	err = mgr.AddDomainDelagate(kp.Identity(), zone)
+	err = mgr.AddDomainDelagate(kp.Identity(), kp.Identity(), zone)
 	require.NoError(t, err)
 
 	// random user add a subomain on the managed domain

--- a/dns/dns_zone.go
+++ b/dns/dns_zone.go
@@ -10,6 +10,7 @@ var (
 	RecordTypeA     = RecordType("a")
 	RecordTypeAAAA  = RecordType("aaaa")
 	RecordTypeCNAME = RecordType("cname")
+	RecordTypeTXT   = RecordType("txt")
 )
 
 // Record define the interface to be a DNS record
@@ -48,6 +49,17 @@ type RecordCname struct {
 // Type implements Record interface
 func (r RecordCname) Type() RecordType {
 	return RecordTypeCNAME
+}
+
+// RecordTXT is a TXT DNS record
+type RecordTXT struct {
+	Text string `json:"text"`
+	TTL  int    `json:"ttl"`
+}
+
+// Type implements Record interface
+func (r RecordTXT) Type() RecordType {
+	return RecordTypeTXT
 }
 
 // Zone is a DNS zone. It hosts multiple records and belong to a owner
@@ -134,7 +146,14 @@ func (rs records) UnmarshalJSON(b []byte) error {
 					return err
 				}
 				r = x
+			case RecordTypeTXT:
+				x := RecordTXT{}
+				if err := json.Unmarshal(b, &x); err != nil {
+					return err
+				}
+				r = x
 			}
+
 			rs[typ] = append(rs[typ], r)
 		}
 	}

--- a/dns/dns_zone_test.go
+++ b/dns/dns_zone_test.go
@@ -26,6 +26,11 @@ func TestZone(t *testing.T) {
 		TTL: 3600,
 	}
 
+	txt := RecordTXT{
+		Text: "hello world",
+		TTL:  3600,
+	}
+
 	z.Add(a)
 	z.Add(aaaa)
 
@@ -46,7 +51,9 @@ func TestZone(t *testing.T) {
 	// add 2 more and remove one in the middle
 	z.Add(b)
 	z.Add(c)
+	z.Add(txt)
 	assert.Equal(t, 3, len(z.Records[RecordTypeA]))
+	assert.Equal(t, 1, len(z.Records[RecordTypeTXT]))
 	z.Remove(b)
 	assert.Equal(t, 2, len(z.Records[RecordTypeA]))
 }


### PR DESCRIPTION
in this PR we make sure for each managed/delegated domain we have a TXT entry `__owner__.<domain>` that holds json information about the gateway ID and the owner ID.

for managed gateway domains (the one that are owned by the gateway) both will be equal.