### PR TITLE
Avoid getting stuck on wrong types

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -28,7 +28,7 @@ require (
 	github.com/shirou/gopsutil v2.20.6+incompatible
 	github.com/stretchr/testify v1.6.1
 	github.com/threefoldtech/tfexplorer v0.4.8-0.20201218110633-b1b2cd7b4975
-	github.com/threefoldtech/zos v0.4.7-rc9.3
+	github.com/threefoldtech/zos v0.4.9-0.20210118140854-23f2d049c270
 	github.com/urfave/cli/v2 v2.2.0
 	github.com/vishvananda/netlink v1.1.0
 	github.com/vishvananda/netns v0.0.0-20200520041808-52d707b772fe // indirect

--- a/go.sum
+++ b/go.sum
@@ -656,6 +656,8 @@ github.com/threefoldtech/zos v0.4.7-rc9.0.0.20201214120726-ece8eec3ee8e h1:5KUDQ
 github.com/threefoldtech/zos v0.4.7-rc9.0.0.20201214120726-ece8eec3ee8e/go.mod h1:5UeekNOvgfdV31yLtf7oOfLR/pN7pxCliyxEIiAzK+M=
 github.com/threefoldtech/zos v0.4.7-rc9.3 h1:TzkA8wgf8kZcHxhvi9cSwa4ZboRg39AcbKI3eGXYBJc=
 github.com/threefoldtech/zos v0.4.7-rc9.3/go.mod h1:o8JvTSg2AiQjXSyTFTsFcaBZY8uU7ItPZhmQQuh9KS4=
+github.com/threefoldtech/zos v0.4.9-0.20210118140854-23f2d049c270 h1:dU+B7EDNfomqpuiaNvxgBzv+3wTEgUHDqgOUoXFoDXU=
+github.com/threefoldtech/zos v0.4.9-0.20210118140854-23f2d049c270/go.mod h1:o8JvTSg2AiQjXSyTFTsFcaBZY8uU7ItPZhmQQuh9KS4=
 github.com/tidwall/pretty v1.0.0 h1:HsD+QiTn7sK6flMKIvNmpqz1qrpP3Ps6jOKIKMooyg4=
 github.com/tidwall/pretty v1.0.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=
 github.com/tinylib/msgp v1.1.2/go.mod h1:+d+yLhGm8mzTaHzB+wgMYrodPfmZrzkirds8fDWklFE=

--- a/provision.go
+++ b/provision.go
@@ -4,12 +4,12 @@ import (
 	"crypto/ed25519"
 	"encoding/hex"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"math"
 	"net"
 	"strconv"
 
+	"github.com/rs/zerolog/log"
 	"github.com/threefoldtech/zos/pkg/crypto"
 
 	"github.com/threefoldtech/tfexplorer/client"
@@ -25,7 +25,6 @@ import (
 
 // ErrUnsupportedWorkload is return when a workload of a type not supported by
 // provisiond is received from the explorer
-var ErrUnsupportedWorkload = errors.New("workload type not supported")
 
 // ReservationType enum list all the supported primitives but the tfgateway
 var (
@@ -258,7 +257,9 @@ func WorkloadToProvisionType(w workloads.Workloader) (*provision.Reservation, er
 			return nil, err
 		}
 	default:
-		return nil, fmt.Errorf("%w (%s) (%T)", ErrUnsupportedWorkload, w.GetWorkloadType().String(), w)
+		// unknown reservation type. The engine will still try to process this.
+		log.Error().Str("type", w.GetWorkloadType().String()).Int("id", int(w.GetID())).Msg("unsupported workload type")
+		return reservation, nil
 	}
 
 	reservation.Data, err = json.Marshal(data)


### PR DESCRIPTION
- Update zos
- Avoid getting stuck on wrong reservation types but sending the bad reservation back to the engine
- the engine will make sure to send the correct result to explorer

Fixes #58